### PR TITLE
Update configuration properties to reference "saveAndRun"

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 			"title": "Save & Run command configuration.",
 			"type": "object",
 			"properties": {
-				"emeraldwalk.runonsave": {
+				"saveAndRun": {
 					"type": "object",
 					"properties": {
 						"commands": {


### PR DESCRIPTION
This prevents vscode from warning about "saveAndRun" not being a known configuration property.